### PR TITLE
Disable a partition offline test when the Hive version is 2 or 3

### DIFF
--- a/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
@@ -54,7 +54,7 @@ function main () {
 
   export HADOOP_MASTER_IP=$(hadoop_master_ip)
   export ALLUXIO_BASE_IMAGE="alluxio/alluxio"
-  export ALLUXIO_IMAGE_TAG="2.1.1"
+  export ALLUXIO_IMAGE_TAG="2.2.0-SNAPSHOT"
 
   start_alluxio_containers
 
@@ -74,7 +74,12 @@ function main () {
   # run product tests
   pushd ${PROJECT_ROOT}
   set +e
-  ./mvnw -B -am -pl presto-hive-hadoop2 test -P test-hive-hadoop2-alluxio \
+  ./mvnw -B -am -pl presto-hive-hadoop2 install -P test-hive-hadoop2-alluxio \
+    -DskipTests \
+    -Dhive.hadoop2.alluxio.host=localhost \
+    -Dhive.hadoop2.alluxio.port=19998 \
+    -DHADOOP_USER_NAME=hive
+  ./mvnw -B -pl presto-hive-hadoop2 test -P test-hive-hadoop2-alluxio \
     -Dhive.hadoop2.alluxio.host=localhost \
     -Dhive.hadoop2.alluxio.port=19998 \
     -DHADOOP_USER_NAME=hive

--- a/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
@@ -74,7 +74,7 @@ function main () {
   # run product tests
   pushd ${PROJECT_ROOT}
   set +e
-  ./mvnw -B -pl presto-hive-hadoop2 test -P test-hive-hadoop2-alluxio \
+  ./mvnw -B -am -pl presto-hive-hadoop2 test -P test-hive-hadoop2-alluxio \
     -Dhive.hadoop2.alluxio.host=localhost \
     -Dhive.hadoop2.alluxio.port=19998 \
     -DHADOOP_USER_NAME=hive

--- a/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
@@ -62,6 +62,7 @@ function main () {
   exec_in_hadoop_master_container sudo -Eu hdfs hdfs dfs -mkdir /alluxio
   exec_in_hadoop_master_container sudo -Eu hdfs hdfs dfs -chmod 777 /alluxio
   exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f /docker/sql/create-test.sql
+  exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f "/files/sql/create-test-hive-${TESTS_HIVE_VERSION_MAJOR}.sql"
 
   # Alluxio currently doesn't support views
   exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -e 'DROP VIEW presto_test_view;'
@@ -74,14 +75,11 @@ function main () {
   # run product tests
   pushd ${PROJECT_ROOT}
   set +e
-  ./mvnw -B -am -pl presto-hive-hadoop2 install -P test-hive-hadoop2-alluxio \
-    -DskipTests \
-    -Dhive.hadoop2.alluxio.host=localhost \
-    -Dhive.hadoop2.alluxio.port=19998 \
-    -DHADOOP_USER_NAME=hive
   ./mvnw -B -pl presto-hive-hadoop2 test -P test-hive-hadoop2-alluxio \
     -Dhive.hadoop2.alluxio.host=localhost \
     -Dhive.hadoop2.alluxio.port=19998 \
+    -Dhive.hadoop2.hiveVersionMajor="${TESTS_HIVE_VERSION_MAJOR}" \
+    -Dhive.hadoop2.timeZone=Asia/Kathmandu \
     -DHADOOP_USER_NAME=hive
   EXIT_CODE=$?
   set -e

--- a/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
@@ -62,7 +62,7 @@ function main () {
   exec_in_hadoop_master_container sudo -Eu hdfs hdfs dfs -mkdir /alluxio
   exec_in_hadoop_master_container sudo -Eu hdfs hdfs dfs -chmod 777 /alluxio
   exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f /docker/sql/create-test.sql
-  exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f "/files/sql/create-test-hive-${TESTS_HIVE_VERSION_MAJOR}.sql"
+  exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f "/docker/sql/create-test-hive-${TESTS_HIVE_VERSION_MAJOR}.sql"
 
   # Alluxio currently doesn't support views
   exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -e 'DROP VIEW presto_test_view;'

--- a/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
@@ -60,7 +60,6 @@ function main () {
     -Dhive.hadoop2.alluxio.host=localhost \
     -Dhive.hadoop2.alluxio.port=19998 \
     -Dhive.hadoop2.hiveVersionMajor="${TESTS_HIVE_VERSION_MAJOR}" \
-    -Dhive.hadoop2.timeZone=Asia/Kathmandu \
     -DHADOOP_USER_NAME=hive
   EXIT_CODE=$?
   set -e

--- a/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_alluxio_tests.sh
@@ -54,7 +54,7 @@ function main () {
 
   export HADOOP_MASTER_IP=$(hadoop_master_ip)
   export ALLUXIO_BASE_IMAGE="alluxio/alluxio"
-  export ALLUXIO_IMAGE_TAG="2.2.0-SNAPSHOT"
+  export ALLUXIO_IMAGE_TAG="2.1.1"
 
   start_alluxio_containers
 

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
@@ -38,22 +38,19 @@ public class TestHiveAlluxioMetastore
             "hive.hadoop2.alluxio.host",
             "hive.hadoop2.alluxio.port",
             "hive.hadoop2.hiveVersionMajor",
-            "hive.hadoop2.timeZone",
     })
     @BeforeClass
-    public void setup(String host, String port, int hiveVersionMajor, String timeZone)
+    public void setup(String host, String port, int hiveVersionMajor)
     {
         this.alluxioAddress = host + ":" + port;
         System.out.println(this.alluxioAddress);
         System.setProperty(PropertyKey.Name.SECURITY_LOGIN_USERNAME, "presto");
         System.setProperty(PropertyKey.Name.MASTER_HOSTNAME, host);
-        HiveConfig hiveConfig = getHiveConfig();
-        hiveConfig.setTimeZone(timeZone);
 
         AlluxioHiveMetastoreConfig alluxioConfig = new AlluxioHiveMetastoreConfig();
         alluxioConfig.setMasterAddress(this.alluxioAddress);
         TableMasterClient client = AlluxioMetastoreModule.createCatalogMasterClient(alluxioConfig);
-        setup(SCHEMA, hiveConfig, new AlluxioHiveMetastore(client));
+        setup(SCHEMA, getHiveConfig(), new AlluxioHiveMetastore(client));
 
         checkArgument(hiveVersionMajor > 0, "Invalid hiveVersionMajor: %s", hiveVersionMajor);
         this.hiveVersionMajor = hiveVersionMajor;

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
@@ -56,6 +56,12 @@ public class TestHiveAlluxioMetastore
         this.hiveVersionMajor = hiveVersionMajor;
     }
 
+    private int getHiveVersionMajor()
+    {
+        checkState(hiveVersionMajor > 0, "hiveVersionMajor not set");
+        return hiveVersionMajor;
+    }
+
     @Override
     public void testBucketSortedTables()
     {
@@ -108,12 +114,6 @@ public class TestHiveAlluxioMetastore
     public void testEmptyTextFile()
     {
         // Alluxio metastore does not support create operations
-    }
-
-    private int getHiveVersionMajor()
-    {
-        checkState(hiveVersionMajor > 0, "hiveVersionMajor not set");
-        return hiveVersionMajor;
     }
 
     @Override


### PR DESCRIPTION
This is also done in the hive test suite because Hive version 2 and 3 does not support a certain command. 